### PR TITLE
Add bin scripts

### DIFF
--- a/bin/copldots-assert-equal
+++ b/bin/copldots-assert-equal
@@ -1,0 +1,18 @@
+#! /usr/bin/env node
+var yaml = require('js-yaml');
+var Ajv = require('ajv');
+var ajv = new Ajv();
+var copldots = require('../index.js');
+var copldSchema = require('../copld-schema.json');
+var validate = ajv.compile(copldSchema);
+var fs = require('fs');
+var sourceDoc = yaml.safeLoad(fs.readFileSync(process.argv[2], 'UTF-8'));
+var valid = validate(sourceDoc);
+var assert = require('assert');
+if (!valid) {
+  console.error(validate.errors);
+  process.exit(1);
+} else {
+  assert.deepEqual(copldots(sourceDoc),
+    JSON.parse(fs.readFileSync(process.argv[3])));
+}

--- a/bin/copldots-build
+++ b/bin/copldots-build
@@ -1,0 +1,21 @@
+#! /usr/bin/env node
+var yaml = require('js-yaml');
+var Ajv = require('ajv');
+var ajv = new Ajv();
+var copldots = require('../index.js');
+var copldSchema = require('../copld-schema.json');
+var validate = ajv.compile(copldSchema);
+var fs = require('fs');
+var sourceDoc = yaml.safeLoad(fs.readFileSync(process.argv[2], 'UTF-8'));
+var valid = validate(sourceDoc);
+var pretty = true;
+if (!valid) {
+  console.error(validate.errors);
+  process.exit(1);
+} else {
+  if (pretty) {
+    console.log(JSON.stringify(copldots(sourceDoc), null, 2));
+  } else {
+    console.log(JSON.stringify(copldots(sourceDoc)));
+  }
+}


### PR DESCRIPTION
So, these are a couple of scripts I've had lying around for a while uncommitted (but I guess they're published to the npm registry?)

They depend on ajv and js-yaml, so I think that's why they haven't been committed - I need to figure out if they should be listed as `devDependencies` or what. Until that question is resolved, **this pull request should not be merged.**